### PR TITLE
COL-581, scripts used by /sbin/service collabosphere start|stop

### DIFF
--- a/init.d/K20collabosphere.sh
+++ b/init.d/K20collabosphere.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+#############################################
+# Stop script for SuiteC invoked by:
+#   sudo /sbin/service collabosphere stop
+#############################################
+
+~/suitec-ops/scripts/stop.sh
+
+exit $?

--- a/init.d/S80collabosphere.sh
+++ b/init.d/S80collabosphere.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+#############################################
+# Start script for SuiteC invoked by:
+#   sudo /sbin/service collabosphere start
+#############################################
+
+~/suitec-ops/scripts/start.sh
+
+exit $?

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -125,7 +125,7 @@ log "Run gulp build"
 node_modules/.bin/gulp build
 
 log "Kill the existing SuiteC process"
-"${scripts_dir}/stop.sh"
+sudo /sbin/service collabosphere stop
 
 log "Copy SuiteC static files to Apache directory: ${DOCUMENT_ROOT}"
 cp -R target/* "${DOCUMENT_ROOT}"
@@ -142,7 +142,7 @@ done
 
 if ${start_server}; then
   log "We are done. SuiteC has been started."
-  "${scripts_dir}/start.sh"
+  sudo /sbin/service collabosphere start
 else
   log "We are done and SuiteC was NOT started, as requested."
 fi


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-581

Ops will copy these to proper dir on dev, qa and prod. Ideally, IS&T would point their init.d script at scripts in `~/suitce-ops/init.d` such that we do not have to manually copy 'em to `~/init.d`.  Maybe we can symlink?