### PR TITLE
NOJIRA, shared_bashrc helps define and manage local SuiteC setup

### DIFF
--- a/scripts/install-locally.sh
+++ b/scripts/install-locally.sh
@@ -1,23 +1,33 @@
 #!/bin/bash
 
-# No git-reset here: we do NOT destroy local work.
-
 # Fail the entire script when one of the commands in it fails
 set -e
 
+echo_usage() {
+  echo "SYNOPSIS"
+  echo "     ${0}"; echo
+  echo "ENVIRONMENT VARIABLES"; echo
+  echo "     DOCUMENT_ROOT"
+  echo "          Apache directory to which we copy SuiteC static files"; echo
+  echo "     SUITEC_BASE_DIR"
+  echo "          Base directory of SuiteC deployment"; echo
+}
+
 "$(dirname ${0})/verify-suitec-base-dir.sh"
 
+[[ "${DOCUMENT_ROOT}" ]] || { echo; echo "[ERROR] 'DOCUMENT_ROOT' is undefined"; echo_usage; exit 1; }
+
 log() {
-  echo; echo "${1}"; echo
+  echo "${1}"; echo
 }
 
 log "Local install of SuiteC is starting."
 
-# Base directory of SuiteC deployment
 cd "${SUITEC_BASE_DIR}"
+find node_modules/ -mindepth 1 -maxdepth 1 -not -name 'col-*' -exec /bin/rm -rf '{}' \+
 
-# Remove third-party node_modules and re-install npm dependencies
-find node_modules/ -mindepth 1 -maxdepth 1 ! -name 'col-*' -exec rm -rf {} +
+log "NPM clean and install"
+npm cache clean
 npm install
 
 log "Remove existing bower dependencies and re-install"

--- a/shared_bashrc/local
+++ b/shared_bashrc/local
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+######################################################################
+# SuiteC developers might find the following aliases, funtions useful.
+#
+# Add the following, in order, to your personal ~/.bash_profile:
+#
+# export SUITEC_BASE='...' # Base directory of local repo
+# export SUITEC_PREVIEW_SERVICE_BASE='...'
+# export SUITEC_OPS_BASE='...'
+# source "${SUITEC_OPS_BASE}/bash_profile/local"
+#
+# WARNING: This file is in a public Git repo. It is vital that you
+#          DO NOT add passwords, LTI keys or any other sensitive data.
+#
+######################################################################
+
+# ----------------
+# SuiteC
+# ----------------
+alias cbase='cd ${SUITEC_BASE}'
+alias cgulpbuild='cd ${SUITEC_BASE} && ./node_modules/.bin/gulp build'
+alias cstart='cd ${SUITEC_BASE} && node app'
+alias cinstall='cd ${SUITEC_BASE} && ${SUITEC_OPS_BASE}/scripts/install-locally.sh'
+
+# Database
+alias cdb='psql collabosphere'
+alias cltikeys="cdb -c \"COPY (select lti_key, lti_secret from canvas where canvas_api_domain='localhost:3100') TO STDOUT WITH CSV\""
+
+# Env variables
+export DOCUMENT_ROOT="${SUITEC_BASE}/public"
+
+# Functions
+cgrep() {
+  cd "${SUITEC_BASE}"
+  grep --exclude-dir={.DS_STORE,.git,logs,npm-debug.log,public/assets/img,public/lib,public/viewer,target} \
+    -rinse *.js *.json *.yml apache/*.js apache/*.template config/*.js config/default.json deploy docs email-templates LICENSE node_modules/col-* public README.md scripts
+}
+
+# ----------------
+# Preview Service
+# ----------------
+alias cpsbase='cd ${SUITEC_PREVIEW_SERVICE_BASE}'
+
+# Functions
+cpsgrep() {
+  cd "${SUITEC_PREVIEW_SERVICE_BASE}"
+  grep -rinse *.js *.json buildspec.yml config deploy etc lib LICENSE README.md s3-data
+}


### PR DESCRIPTION
SuiteC devs can use `shared_bashrc/local` to share useful BASH aliases, functions, etc. I'll let PR reviewer decide the merits. E.g., alias 'cinstall' runs `install-locally.sh`.
