### PR TITLE
NOJIRA Data migration scripts: Optionally include passwords, migrate Canvas table

### DIFF
--- a/scripts/pull-data.sh
+++ b/scripts/pull-data.sh
@@ -5,16 +5,20 @@ set -e
 
 echo_usage() {
   echo "SYNOPSIS"
-  echo "     ${0} -d db_connection [-c canvas_hostname [-r replacement_canvas_hostname]]"; echo
+  echo "     ${0} -d db_connection [-c canvas_hostname [-r replacement_canvas_hostname]] [-a]"; echo
   echo "DESCRIPTION"
   echo "Available options"
   echo "     -d      Database connection information in the form 'host:port:database:username'. Required."
+  echo "     -a      Pull all database tables including the canvas table. Optional."
   echo "     -c      Hostname of the Canvas instance for which SuiteC course data should be pulled. Optional, defaults to all instances."
   echo "     -r      If provided, all references to Canvas-hosted resources will be changed to this hostname. Optional, requires -c."
 }
 
-while getopts "c:d:r:" arg; do
+while getopts "ac:d:r:" arg; do
   case ${arg} in
+    a)
+      all_tables=true
+      ;;
     c)
       source_canvas="${OPTARG}"
       ;;
@@ -24,6 +28,7 @@ while getopts "c:d:r:" arg; do
       db_port=${db_params[1]}
       db_database=${db_params[2]}
       db_username=${db_params[3]}
+      db_password=${db_params[4]}
       ;;
     r)
       replacement_canvas="${OPTARG}"
@@ -37,21 +42,23 @@ done
   echo_usage
   exit 1
 }
-[[ "${replacement_canvas}" ]] && ! [[ "${source_canvas}" ]] && { 
+[[ "${replacement_canvas}" ]] && ! [[ "${source_canvas}" ]] && {
   echo "[ERROR] A replacement Canvas hostname cannot be specified without also specifying a source Canvas instance."; echo
   echo_usage
   exit 1
 }
 
-echo -n "Enter database password: "
-read -s db_password; echo; echo
+if ! [[ "${db_password}" ]]; then
+  echo -n "Enter database password: "
+  read -s db_password; echo; echo
+fi
 
 if [[ "${replacement_canvas}" ]]; then
   echo "Will pull data for all courses hosted under ${source_canvas}, changing host references to ${replacement_canvas}."
 elif [[ "${source_canvas}" ]]; then
   echo "Will pull data for all courses hosted under ${source_canvas}."
 else
-  echo "Will pull data for all courses."  
+  echo "Will pull data for all courses."
 fi
 echo
 
@@ -127,7 +134,7 @@ else
 
 fi
 
-# Next, pull data from tables that do contain references to specific Canvas hostnames. 
+# Next, pull data from tables that do contain references to specific Canvas hostnames.
 
 # If the Canvas hostname should be changed, run a replace command on certain columns as part of the query.
 
@@ -135,7 +142,7 @@ if [[ "${replacement_canvas}" ]]; then
 
   output_csv "assets" "select a.id, a.type, a.url,
                 replace(a.download_url, '${source_canvas}', '${replacement_canvas}') as download_url,
-                a.title, a.canvas_assignment_id, a.description, a.thumbnail_url, a.image_url, a.mime, 
+                a.title, a.canvas_assignment_id, a.description, a.thumbnail_url, a.image_url, a.mime,
                 a.source, a.body, a.likes, a.dislikes, a.views, a.comment_count, a.created_at, a.updated_at,
                 a.deleted_at, a.course_id, a.pdf_url, a.preview_status, a.preview_metadata, a.visible
               from assets a
@@ -150,7 +157,7 @@ if [[ "${replacement_canvas}" ]]; then
                 on a.course_id = c.id and c.canvas_api_domain = '${source_canvas}')
               on awe.asset_id = a.id"
 
-  output_csv "courses" "select c.id, c.canvas_course_id, c.enable_upload, c.name, 
+  output_csv "courses" "select c.id, c.canvas_course_id, c.enable_upload, c.name,
                 replace(c.assetlibrary_url, '${source_canvas}', '${replacement_canvas}') as assetlibrary_url,
                 replace(c.dashboard_url, '${source_canvas}', '${replacement_canvas}') as dashboard_url,
                 replace(c.engagementindex_url, '${source_canvas}', '${replacement_canvas}') as engagementindex_url,
@@ -194,7 +201,7 @@ elif [[ "${source_canvas}" ]]; then
 
   output_csv "whiteboards" "select w.* from whiteboards w
               join courses c
-              on w.course_id = c.id and c.canvas_api_domain = '${source_canvas}'"              
+              on w.course_id = c.id and c.canvas_api_domain = '${source_canvas}'"
 
   output_csv "whiteboard_elements" "select we.* from whiteboard_elements we
               join (whiteboards w join courses c
@@ -208,9 +215,15 @@ else
   output_csv "assets" "select * from assets"
   output_csv "asset_whiteboard_elements" "select * from asset_whiteboard_elements"
   output_csv "courses" "select * from courses"
-  output_csv "whiteboards" "select * from whiteboards"              
+  output_csv "whiteboards" "select * from whiteboards"
   output_csv "whiteboard_elements" "select * from whiteboard_elements"
 
+fi
+
+# If all tables are requested, pull the Canvas table as well.
+
+if [[ "${all_tables}" ]]; then
+  output_csv "canvas" "select * from canvas"
 fi
 
 echo "Done."

--- a/scripts/push-data.sh
+++ b/scripts/push-data.sh
@@ -5,24 +5,29 @@ set -e
 
 echo_usage() {
   echo "SYNOPSIS"
-  echo "     ${0} -d db_connection"; echo
+  echo "     ${0} -d db_connection [-a] [-i]"; echo
   echo "DESCRIPTION"
   echo "Available options"
   echo "     -d      Database connection information in the form 'host:port:database:username'. Required."
+  echo "     -a      Push all database tables including the canvas table. Optional."
   echo "     -i      Mark all courses as inactive after push (may be desirable when populating a test environment). Optional."
 }
 
 # Default
 inactivate_courses=false
 
-while getopts "d:i" arg; do
+while getopts "ad:i" arg; do
   case ${arg} in
+    a)
+      all_tables=true
+      ;;
     d)
       db_params=(${OPTARG//:/ })
       db_host=${db_params[0]}
       db_port=${db_params[1]}
       db_database=${db_params[2]}
       db_username=${db_params[3]}
+      db_password=${db_params[4]}
       ;;
     i)
       inactivate_courses=true
@@ -37,13 +42,17 @@ done
   exit 1
 }
 
-# Because of foreign key constraints, we must populate tables in order of association. The 'canvas' table
-# in the database remains unchanged.
-declare -a tables=(courses 
-                   users assets asset_users comments 
+# Because of foreign key constraints, we must populate tables in order of association.
+declare -a tables=(courses
+                   users assets asset_users comments
                    activity_types activities
-                   categories assets_categories 
+                   categories assets_categories
                    whiteboards whiteboard_members asset_whiteboard_elements whiteboard_elements chats)
+
+# Prepend the canvas table only if requested.
+if [[ "${all_tables}" ]]; then
+  tables=(canvas ${tables[*]})
+fi
 
 # Check that all CSV files exist in the local directory.
 for table in "${tables[@]}"; do
@@ -53,8 +62,10 @@ for table in "${tables[@]}"; do
   }
 done
 
-echo -n "Enter database password: "
-read -s db_password; echo; echo
+if ! [[ "${db_password}" ]]; then
+  echo -n "Enter database password: "
+  read -s db_password; echo; echo
+fi
 
 echo "WARNING: You are on the verge of deleting ALL existing course and user data from the database '${db_database}' at ${db_host}:${db_port}."
 echo -n "To accept the consequences, type 'consentio': "
@@ -66,7 +77,13 @@ read confirmation; echo
 }
 
 echo "Clearing out existing data..."
-# Truncating the course and user tables cascades along foreign key references and clears everything in one fell swoop.
+
+# Truncate the canvas table if necessary.
+if [[ "${all_tables}" ]]; then
+  PGPASSWORD=${db_password} psql -h ${db_host} -p ${db_port} -d ${db_database} --username ${db_username} -c "truncate canvas cascade"; echo
+fi
+
+# Truncating course, user and category tables cascades along foreign key references and clears everything in one fell swoop.
 PGPASSWORD=${db_password} psql -h ${db_host} -p ${db_port} -d ${db_database} --username ${db_username} -c "truncate courses cascade"; echo
 PGPASSWORD=${db_password} psql -h ${db_host} -p ${db_port} -d ${db_database} --username ${db_username} -c "truncate users cascade"; echo
 PGPASSWORD=${db_password} psql -h ${db_host} -p ${db_port} -d ${db_database} --username ${db_username} -c "truncate categories cascade"; echo


### PR DESCRIPTION
Leaving aside the whitespace changes, this makes two enhancements to the push/pull scripts:
- Optionally include the 'canvas' table in migrations, which we'll want to do when refreshing a production environment;
- Accept password value as an argument, which will allow a wrapper script to extract passwords from local config files and pass them on.